### PR TITLE
Use GitHub as the source of documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # H2 API Plugin
+[![Jenkins Plugin](https://img.shields.io/jenkins/plugin/v/h2-api.svg)](https://plugins.jenkins.io/h2-api)
+[![Jenkins Plugin Installs](https://img.shields.io/jenkins/plugin/i/h2-api.svg?color=blue)](https://plugins.jenkins.io/h2-api)
 
-This plugin is a shared library. It provides the H2 jar so that other plugins can consume H2 without duplication and without classpath collisions.
-
-See the [Plugin Wiki](https://wiki.jenkins-ci.org/display/JENKINS/H2+API+Plugin) for release information and documentation. 
+This plugin is a shared library. It provides the [H2](https://www.h2database.com/) jar so that other plugins can consume H2 without duplication and without classpath collisions. 
+To check which plugins are using this, see the [list of dependent plugins](https://plugins.jenkins.io/h2-api/#dependencies).

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
     <packaging>hpi</packaging>
 
     <name>H2 API Plugin</name>
-    <url>https://wiki.jenkins-ci.org/display/JENKINS/H2+API+Plugin</url>
+    <url>https://github.com/jenkinsci/h2-api-plugin</url>
 
     <properties>
         <jenkins.version>2.89.4</jenkins.version>


### PR DESCRIPTION
The Wiki page is non-existent so this should improve the presentation of this plugin at https://plugins.jenkins.io/h2-api