### PR TITLE
Test with Java 21.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,6 +4,6 @@
 buildPlugin(
   useContainerAgent: true,
   configurations: [
+    [platform: 'linux', jdk: 21],
     [platform: 'linux', jdk: 17],
-    [platform: 'linux', jdk: 11],
 ])


### PR DESCRIPTION
Java 21 was released Sep 19, 2023. We want to announce full support for Java 21 in early October and would like the most used plugins to be compiled and tested with Java 21.

The acceptance test harness and plugin bill of materials tests are already passing with Java 21. This is a further step to improve plugin readiness for use with Java 21 and for development with Java 21.

The change intentionally tests only two Java configurations, Java 17 and Java 21 because we believe that the risk of a regression that only affects Java 11 is shallow. We generate Java 11 byte code with the Java 17 and the Java 21 builds, so we're already testing Java 11 byte code.

Testing done
===

Confirmed tests pass with Java 21 on Linux.

### Submitter checklist
- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- ~~Link to relevant issues in GitHub or Jira~~
- ~~Link to relevant pull requests, esp. upstream and downstream changes~~
- [X] Ensure you have provided tests - that demonstrates feature works or fixes the issue